### PR TITLE
disable mongoose pluralizing of database collections

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const app = express();
 const port = process.env.PORT || 8080;
 app.listen(port, () => console.log(`Listening on port ${port}`));
 
+mongoose.pluralize(null); // Disable pluralizing of collection name
 
 // TODO: Move this section to separate file for organizational purposes 
 // Connect to DB


### PR DESCRIPTION
Mongoose automatically pluralizes MongoDB collection names, so that this: 

`var PendingArtistMural = mongoose.model("pendingArtist", pendingArtistSchema);
`
which you'd expect to create with the 'pendingArtist' collection, would actually create a 'pendingArtists' collection.

This added line disables that pluralization.



